### PR TITLE
Won't trycatch different types

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ function isBuffer(x) {
 function objEquiv(a, b, opts) {
   /* eslint max-statements: [2, 50] */
   var i, key;
+  if (typeof a !== typeof b) { return false; }
   if (isUndefinedOrNull(a) || isUndefinedOrNull(b)) { return false; }
 
   // an identical 'prototype' property.

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -316,3 +316,15 @@ test('arrays and objects', function (t) {
 
   t.end();
 });
+
+test('functions', function (t) {
+  function f() {}
+
+  t.ok(equal(f, f), 'a function is equal to itself');
+  t.ok(equal(f, f, { strict: true }), 'strict: a function is equal to itself');
+
+  t.notOk(equal(function () {}, function () {}), 'two different functions are never equal');
+  t.notOk(equal(function () {}, function () {}, { strict: true }), 'strict: two different functions are never equal');
+
+  t.end();
+});


### PR DESCRIPTION
The current version will hit the trycatch in objEquiv if you compare, for example, `false` to `[]`

This should significantly improve the performance of checks between values of different types.

Tests pass, however I'm not totally confident that there are enough tests to catch potential edge cases.
