### PR TITLE
add type check to support browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,5 +90,5 @@ function objEquiv(a, b, opts) {
     key = ka[i];
     if (!deepEqual(a[key], b[key], opts)) return false;
   }
-  return true;
+  return typeof a === typeof b;
 }

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -82,3 +82,8 @@ test('buffers', function (t) {
     t.ok(equal(Buffer('xyz'), Buffer('xyz')));
     t.end();
 });
+
+test('booleans and arrays', function (t) {
+    t.notOk(equal(true, []));
+    t.end();
+})


### PR DESCRIPTION
the test i added and a previous test comparing `'3'` and `[3]` both fail in chrome latest without this addition.