### PR TITLE
Update travis configuration to test on node 0.12 and 0.10, fixes tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 0.4
-  - 0.6
+  - "0.10"
+  - "0.12"


### PR DESCRIPTION
https://travis-ci.org/substack/node-deep-equal is failing because the .travis.yml is configured to only test on very old versions of nodejs, 0.4 and 0.6, which fail to load the newer tape 3.5.0 dev dependency. 

This PR updates .travis.yml to test on 0.12 and 0.10, so the tests pass