### PR TITLE
Added support for NaNs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,22 @@
 var objectKeys = require('object-keys');
 var isArguments = require('is-arguments');
+var is = require('object-is');
 
 function deepEqual(actual, expected, options) {
   var opts = options || {};
-  // 7.1. All identical values are equivalent, as determined by ===.
-  if (actual === expected) {
-    return true;
 
-  } else if (actual instanceof Date && expected instanceof Date) {
+  // 7.1. All identical values are equivalent, as determined by ===.
+  if (opts.strict ? is(actual, expected) : actual === expected) {
+    return true;
+  }
+
+  if (actual instanceof Date && expected instanceof Date) {
     return actual.getTime() === expected.getTime();
+  }
 
   // 7.3. Other pairs that do not both pass typeof value == 'object', equivalence is determined by ==.
-  } else if (!actual || !expected || (typeof actual != 'object' && typeof expected != 'object')) {
-    return opts.strict ? actual === expected : actual == expected;
+  if (!actual || !expected || (typeof actual != 'object' && typeof expected != 'object')) {
+    return opts.strict ? is(actual, expected) : actual == expected;
   }
 
   /*

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "is-arguments": "^1.0.4",
+    "object-is": "^1.0.1",
     "object-keys": "^1.1.1"
   },
   "devDependencies": {

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -191,3 +191,40 @@ test('null == undefined', function (t) {
   t.notOk(equal(null, undefined, { strict: true }));
   t.end();
 });
+
+test('null == undefined', function (t) {
+  t.ok(equal(null, undefined), 'null == undefined');
+  t.ok(equal(undefined, null), 'undefined == null');
+  t.notOk(equal(null, undefined, { strict: true }), 'null !== undefined');
+  t.notOk(equal(undefined, null, { strict: true }), 'undefined !== null');
+  t.end();
+});
+
+test('NaNs', function (t) {
+  t.notOk(equal(NaN, NaN), 'NaN is not NaN');
+  t.ok(equal(NaN, NaN, { strict: true }), 'strict: NaN is NaN');
+
+  t.notOk(equal({ a: NaN }, { a: NaN }), 'two equiv objects with a NaN value are not equiv');
+  t.ok(equal({ a: NaN }, { a: NaN }, { strict: true }), 'strict: two equiv objects with a NaN value are equiv');
+
+  t.notOk(equal(NaN, 1), 'NaN !== 1');
+  t.notOk(equal(NaN, 1, { strict: true }), 'strict: NaN !== 1');
+
+  t.end();
+});
+
+test('zeroes', function (t) {
+  t.ok(equal(0, -0), '0 is -0');
+  t.ok(equal(-0, 0), '-0 is 0');
+
+  t.notOk(equal(0, -0, { strict: true }), 'strict: 0 is -0');
+  t.notOk(equal(-0, 0, { strict: true }), 'strict: -0 is 0');
+
+  t.ok(equal({ a: 0 }, { a: -0 }), 'two objects with a same-keyed 0/-0 value are equal');
+  t.ok(equal({ a: -0 }, { a: 0 }), 'two objects with a same-keyed -0/0 value are equal');
+
+  t.notOk(equal({ a: 0 }, { a: -0 }, { strict: true }), 'strict: two objects with a same-keyed 0/-0 value are equal');
+  t.notOk(equal({ a: -0 }, { a: 0 }, { strict: true }), 'strict: two objects with a same-keyed -0/0 value are equal');
+
+  t.end();
+});


### PR DESCRIPTION
Add support for NaN when doing deep-equal on objects that may contain them. As far as JS is concerned NaN is never equal to anything else, including itself, so the following would not match when passed through deep-equal:

```
{a: NaN}
{a: NaN}
```

Even though they are to all intents and purposes the same.
To work around this I've added a call to Object.is() to check the identity of the actual and expected objects passed to deepEqual().
