### PR TITLE
fix strict equality check for prototypes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - '0.8'
   - '0.10'
   - '0.12'
   - 'iojs'
+  - '4.1'
 before_install:
   - npm install -g npm@latest

--- a/index.js
+++ b/index.js
@@ -44,8 +44,8 @@ function objEquiv(a, b, opts) {
   var i, key;
   if (isUndefinedOrNull(a) || isUndefinedOrNull(b))
     return false;
-  // an identical 'prototype' property.
-  if (a.prototype !== b.prototype) return false;
+  if (opts.strict && Object.getPrototypeOf(a) !== Object.getPrototypeOf(b))
+    return false;
   //~~~I've managed to break Object.keys through screwy arguments passing.
   //   Converting to array solves the problem.
   if (isArguments(a)) {

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -93,3 +93,16 @@ test('null == undefined', function (t) {
     t.notOk(equal(null, undefined, { strict: true }))
     t.end()
 })
+
+test('prototypes', function (t) {
+    function A() {}
+    function B() {}
+
+    t.ok(equal(new A, new A, { strict: true }))
+    t.notOk(equal(new A, new B, { strict: true }))
+
+    t.ok(equal(new A, new A))
+    t.ok(equal(new A, new B))
+    t.end()
+})
+


### PR DESCRIPTION
Fixes #25

As per [assert.js](https://github.com/nodejs/node/blob/31c971d64114af02125e9af8e4f034bfce4eb685/lib/assert.js#L194) in node repo
