### PR TITLE
Add strictOrder option

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,8 +77,12 @@ function objEquiv(a, b, opts) {
   if (ka.length != kb.length)
     return false;
   //the same set of keys (although not necessarily the same order),
-  ka.sort();
-  kb.sort();
+
+  if(!opts.strictOrder){
+    ka.sort();
+    kb.sort();
+  }
+  
   //~~~cheap key test
   for (i = ka.length - 1; i >= 0; i--) {
     if (ka[i] != kb[i])

--- a/readme.markdown
+++ b/readme.markdown
@@ -40,6 +40,9 @@ If `opts.strict` is `true`, use strict equality (`===`) to compare leaf nodes.
 The default is to use coercive equality (`==`) because that's how
 `assert.deepEqual()` works by default.
 
+If `opts.strictOrder` is `true`, fail equality if objects keys are in a different order
+The default is `false` 
+
 # install
 
 With [npm](http://npmjs.org) do:

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -33,6 +33,15 @@ test('strict equal', function (t) {
     t.end();
 });
 
+test('strict order equal', function (t) {
+    t.notOk(equal(
+        [ { a: 3, b: 4 } ],
+        [ { b: 4, a: 3 } ],
+        { strictOrder: true }
+    ));
+    t.end();
+});
+
 test('non-objects', function (t) {
     t.ok(equal(3, 3));
     t.ok(equal('beep', 'beep'));


### PR DESCRIPTION
In some cases ordering of object keys are important. Add a strictOrder options that cancels keys sorting before equality testing.
