### PR TITLE
Add support for skipping function comparisons.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore development stuff
+/node_modules
+*.sw[onp]

--- a/index.js
+++ b/index.js
@@ -13,6 +13,12 @@ var deepEqual = module.exports = function (actual, expected, opts) {
 
   // 7.3. Other pairs that do not both pass typeof value == 'object',
   // equivalence is determined by ==.
+  } else if (isFunction(actual) && isFunction(expected)) {
+    if (opts.skip === 'functions') {
+      return true
+    }
+
+    return actual == expected;
   } else if (!actual || !expected || typeof actual != 'object' && typeof expected != 'object') {
     return opts.strict ? actual === expected : actual == expected;
 
@@ -29,6 +35,10 @@ var deepEqual = module.exports = function (actual, expected, opts) {
 
 function isUndefinedOrNull(value) {
   return value === null || value === undefined;
+}
+
+function isFunction(value) {
+  return !!(value && value.constructor && value.call && value.apply);
 }
 
 function isBuffer (x) {
@@ -90,5 +100,6 @@ function objEquiv(a, b, opts) {
     key = ka[i];
     if (!deepEqual(a[key], b[key], opts)) return false;
   }
+
   return typeof a === typeof b;
 }

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -93,3 +93,33 @@ test('null == undefined', function (t) {
     t.notOk(equal(null, undefined, { strict: true }))
     t.end()
 })
+
+test('functions', function(t) {
+  var f1 = function() {},
+      f2 = function() {};
+
+  t.notOk(equal(f1, f2));
+  t.ok(equal(f1, f1));
+  t.ok(equal(f1, f2, { skip: 'functions'}));
+  t.end();
+})
+
+test('nested functions', function(t) {
+  var f1 = function() {},
+      f2 = function() {};
+
+  t.notOk(equal({'test': f1}, {'test':f2}));
+  t.ok(equal({'test': f1}, {'test':f1}));
+  t.ok(equal({'test': f1}, {'test':f2}, { skip: 'functions' }));
+  t.end();
+});
+
+test('arrays of functions', function(t) {
+  var f1 = function() {},
+      f2 = function() {};
+
+  t.notOk(equal([f1], [f2]));
+  t.ok(equal([f1], [f1]));
+  t.ok(equal([f1], [f2], { skip: 'functions' }));
+  t.end();
+});


### PR DESCRIPTION
We've run in to a number of scenarios where by we want to just assume two functions are equivalent. This PR adds support for detecting function comparisons and conditionally just skipping them or assuming that they're equivalent.
