### PR TITLE
Added support to ignore specific fields.

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,6 +88,9 @@ function objEquiv(a, b, opts) {
   //~~~possibly expensive deep test
   for (i = ka.length - 1; i >= 0; i--) {
     key = ka[i];
+    if( opts.ignores && opts.ignores.indexOf(key) >= 0 ) {
+      continue;
+    }
     if (!deepEqual(a[key], b[key], opts)) return false;
   }
   return typeof a === typeof b;

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -93,3 +93,21 @@ test('null == undefined', function (t) {
     t.notOk(equal(null, undefined, { strict: true }))
     t.end()
 })
+
+test('ignore fields', function (t) {
+    t.notOk(equal(
+        { x : 5, y : [6] },
+        { x : 5, y : 6 }
+    ));
+    t.ok(equal(
+        { x : 5, y : [6] },
+        { x : 5, y : 6 },
+        { ignores : ['y']}
+    ));
+    t.notOk(equal(
+        { x : 5, y : [6] },
+        { x : 5, y : 6 },
+        { ignores : ['x']}
+    ));
+    t.end();
+})


### PR DESCRIPTION
User can pass an optional _ignores_ array of strings. All the properties whose name is contained into the array will be skipped when comparing.