### PR TITLE
[Breaking] ensure `Error` objects compare properly

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
       "files": ["example/**", "test/**"],
       "rules": {
         "array-bracket-newline": 0,
+        "max-lines": 0,
         "max-params": 0,
         "max-statements": 0,
         "no-console": 0,

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function isBuffer(x) {
 }
 
 function objEquiv(a, b, opts) {
-  /* eslint max-statements: [2, 50] */
+  /* eslint max-statements: [2, 70] */
   var i, key;
   if (typeof a !== typeof b) { return false; }
   if (isUndefinedOrNull(a) || isUndefinedOrNull(b)) { return false; }
@@ -59,6 +59,14 @@ function objEquiv(a, b, opts) {
   if (a.prototype !== b.prototype) { return false; }
 
   if (isArguments(a) !== isArguments(b)) { return false; }
+
+  // TODO: replace when a cross-realm brand check is available
+  var aIsError = a instanceof Error;
+  var bIsError = b instanceof Error;
+  if (aIsError !== bIsError) { return false; }
+  if (aIsError || bIsError) {
+    if (a.name !== b.name || a.message !== b.message) { return false; }
+  }
 
   var aIsRegex = isRegex(a);
   var bIsRegex = isRegex(b);

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -342,3 +342,11 @@ test('functions', function (t) {
 
   t.end();
 });
+
+test('Errors', function (t) {
+  t.deepEqualTest(new Error('xyz'), new Error('xyz'), 'two errors of the same type with the same message', true, true, false);
+  t.deepEqualTest(new Error('xyz'), new TypeError('xyz'), 'two errors of different types with the same message', false, false);
+  t.deepEqualTest(new Error('xyz'), new Error('zyx'), 'two errors of the same type with a different message', false, false);
+
+  t.end();
+});


### PR DESCRIPTION
I tried to support `Error` object. It is easy to cover almost all cases.
But it is too difficult to make sure that supporting current supported browsers and nodejs.

Refs:
- [Node.js v9.11.1 Documentation#Errors](https://nodejs.org/dist/latest-v9.x/docs/api/errors.html)
- [Error | MDN web docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)

- - -

I felt we should avoid to support to compare `Error` objects.
We might better to put some comments on `README.md` about that.

- - -

Fixes #47.
Almost same solution: https://github.com/substack/node-deep-equal/pull/48