### PR TITLE
Feature/compare functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ var deepEqual = module.exports = function (actual, expected, opts) {
   // 7.1. All identical values are equivalent, as determined by ===.
   if (actual === expected) {
     return true;
-
+  } else if (typeof actual === 'function' && typeof expected === 'function') {
+    return deepEqual(actual(), expected());
   } else if (actual instanceof Date && expected instanceof Date) {
     return actual.getTime() === expected.getTime();
 

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -11,6 +11,40 @@ test('equal', function (t) {
     t.end();
 });
 
+test('function returning object literal with functions equal', function (t) {
+    const Test = (a) => {
+        return {
+            test() {
+                return a;
+            }
+        }
+    }
+    const a = Test('a');
+    const b = Test('a');
+    t.ok(equal(
+        a,
+        b
+    ));
+    t.end();
+});
+
+test('function returning object literal with functions not equal', function (t) {
+    const Test = (a) => {
+        return {
+            test() {
+                return a;
+            }
+        }
+    }
+    const a = Test('a');
+    const b = Test('c');
+    t.notOk(equal(
+        a,
+        b
+    ));
+    t.end();
+});
+
 test('not equal', function (t) {
     t.notOk(equal(
         { x : 5, y : [6] },


### PR DESCRIPTION
While working with [Dinero.js](https://github.com/sarahdayan/dinero.js), I realized the deep comparison wasn't working. Upon a little investigation, it looks like functions aren't compared correctly. A `Dinero` object returns an object literal with functions, which is why it was failing.

Adding a simple test in the primary method seems to work:

```
} else if (typeof actual === 'function' && typeof expected === 'function') {
  return deepEqual(actual(), expected());
}
```

The new test goes through `deepEqual` again, in the case the function returns a non-comparable type, like an array, object, etc.

Before the changes:

```
const A = (a) => {
  return {
    test: function() {
      return a;
    }
  }
}
const a = A('a');
const b = A('a');
console.log(deepEqual(a, b)); // false
```

After the changes:

```
const A = (a) => {
  return {
    test: function() {
      return a;
    }
  }
}
const a = A('a');
const b = A('a');
console.log(deepEqual(a, b)); // true

const c = A('c');
const d = A('d');
console.log(deepEqual(c, d)); // false
```

All the tests run OK. I added two new tests as well to test this new behavior.